### PR TITLE
Fix IBM Cloud Kubernetes test

### DIFF
--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -56,7 +56,7 @@ kubectl_deploy() {
 
     echo "Waiting for pods to be running"
     i=0
-    while [[ $(kubectl get pods | grep -c Running) -ne 4 ]]; do
+    while [[ $(kubectl get pods -l app=offce-space | grep -c Running) -ne 4 ]]; do
         if [[ ! "$i" -lt 24 ]]; then
             echo "Timeout waiting on pods to be ready. Test FAILED"
             exit 1


### PR DESCRIPTION
Previously, the test is checking all pods that are running.
This resulted into travis errors as the test cluster is running multiple tests on multiple repos.
This fix checks the pods for this spring boot app only.