### PR TITLE
Update Bluemix CLI Installation for Travis

### DIFF
--- a/scripts/install_bx.sh
+++ b/scripts/install_bx.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
 fi
 
 echo "Installing Bluemix CLI"
-curl -L http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/latest/Bluemix_CLI_amd64.tar.gz > Bluemix_CLI.tar.gz
+curl -L https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/latest/IBM_Cloud_CLI_amd64.tar.gz > Bluemix_CLI.tar.gz
 tar -xvf Bluemix_CLI.tar.gz
 sudo ./Bluemix_CLI/install_bluemix_cli
 


### PR DESCRIPTION
This commit updates the Bluemix CLI download location in install.sh.
This should get the latest bx cli installation in Travis builds.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>