### PR TITLE
Disable bx cli version check

### DIFF
--- a/scripts/install_bx.sh
+++ b/scripts/install_bx.sh
@@ -10,6 +10,10 @@ curl -L https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/latest/IBM_Clou
 tar -xvf Bluemix_CLI.tar.gz
 sudo ./Bluemix_CLI/install_bluemix_cli
 
+echo "Configuring bx to disable version check"
+bx config --check-version=false
+echo "Checking bx version"
+bx --version
 echo "Installing Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 


### PR DESCRIPTION
Current Travis builds are failing because of a timeout waiting for
input regarding an update request for the bluemix cli. This commit
modifies the install.sh script to not check for an update and to
rather use the version downloaded.